### PR TITLE
implement coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: .
-      - run: yarn test
+      - run: yarn test-ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage
 node_modules
 dist
 yarn-error.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # SRS Project
+
+[![CircleCI](https://circleci.com/gh/SRS-Project/app.svg?style=shield)](https://circleci.com/gh/SRS-Project/app)
+[![Coverage Status](https://coveralls.io/repos/github/SRS-Project/app/badge.svg?branch=master)](https://coveralls.io/github/SRS-Project/app?branch=master)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "awesome-typescript-loader": "^5.0.0",
     "babel-loader": "^8.0.0-beta",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "coveralls": "^3.0.1",
     "cross-env": "^5.1.4",
     "electron": "^1.8.6",
     "electron-compile": "^6.4.2",
@@ -68,6 +69,7 @@
     "webpack-merge": "^4.1.2"
   },
   "jest": {
+    "collectCoverage": true,
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "test": "jest"
+    "test": "jest",
+    "test-ci": "jest --coverage --coverageReporters=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,6 +2307,16 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
+coveralls@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.1.tgz#12e15914eaa29204e56869a5ece7b9e1492d2ae2"
+  dependencies:
+    js-yaml "^3.6.1"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.5"
+    minimist "^1.2.0"
+    request "^2.79.0"
+
 cpx@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/cpx/-/cpx-1.5.0.tgz#185be018511d87270dedccc293171e37655ab88f"
@@ -4682,7 +4692,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
@@ -4881,6 +4891,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcov-parse@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+
 left-pad@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -5029,6 +5043,10 @@ lodash.sortby@^4.7.0:
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+log-driver@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -6550,7 +6568,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.45.0, request@^2.83.0:
+request@^2.45.0, request@^2.79.0, request@^2.83.0:
   version "2.85.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
   dependencies:


### PR DESCRIPTION
## Why

Coverage is a good metric to have a general overview of how much of the code base is tested. Since the project is still in it's initial phase, this will help maintain high coverage while the project is under development and encourage tests to be written.

## What

This enables coverage output when tests are ran locally and reporting to `coveralls.io` on the CI. It also includes badges to the `README` so that we have easy access to the current status of the project.