### PR TITLE
exclude spec.tsx files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,8 @@
   "include": [
     "src/**/*",
     "./webpack*"
+  ],
+  "exclude": [
+    "**/*.spec.tsx"
   ]
 }


### PR DESCRIPTION
## Why

Failed builds because the spec is wrong are silly. The spec being wrong should result in tests being wrong.

## What

This excludes test files from being compiled by Webpack. So now you better run tests before pushing or all will know your shame.

## Notes

This one fails tests because master branch (the source of this branch) has no tests. No tests means jest exits with a `1`.