### PR TITLE
Revert excluding specs in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,5 @@
       "src/*": ["src/*"]
     }
   },
-  "include": [
-    "src/**/*",
-    "./webpack*"
-  ],
-  "exclude": [
-    "**/*.spec.tsx"
-  ]
+  "include": ["src/**/*", "./webpack*"]
 }


### PR DESCRIPTION
## Why

By excluding the spec files in TS we are unable to commit any changes to specs due the pre-commit linter failing.

## What

Revert https://github.com/SRS-Project/app/pull/16

CI now also includes build, so we should notice early when things go wrong.